### PR TITLE
fix: editor should properly adapt to flex container

### DIFF
--- a/projects/editor/src/components/editor/editor.component.less
+++ b/projects/editor/src/components/editor/editor.component.less
@@ -20,6 +20,7 @@
 
 .t-wrapper {
     display: flex;
+    block-size: 100%;
     max-block-size: inherit;
     min-block-size: inherit;
     cursor: text;
@@ -64,7 +65,6 @@
 
 .t-scrollbar {
     display: flex;
-    min-block-size: 100%;
     padding-bottom: 0.75rem;
     box-sizing: border-box;
     flex: 1;


### PR DESCRIPTION
Close #1325

### Before
![before fix](https://github.com/user-attachments/assets/85b32a9c-6b37-488e-b345-79813cd43f8d)

### After
![after fix](https://github.com/user-attachments/assets/647070f6-e6f9-4eda-82b1-ed384fd49bc4)
