### PR TITLE
fix: fix link editor's input auto-focus

### DIFF
--- a/projects/editor/components/editor/editor.component.ts
+++ b/projects/editor/components/editor/editor.component.ts
@@ -20,7 +20,6 @@ import {
     TUI_FALSE_HANDLER,
     TUI_TRUE_HANDLER,
     TuiActiveZone,
-    tuiAutoFocusOptionsProvider,
     TuiControl,
     tuiInjectElement,
     tuiWatch,
@@ -28,7 +27,6 @@ import {
 } from '@taiga-ui/cdk';
 import type {TuiDropdownDirective} from '@taiga-ui/core';
 import {
-    TUI_ANIMATIONS_DEFAULT_DURATION,
     TUI_APPEARANCE_OPTIONS,
     TuiAppearance,
     tuiAppearanceFocus,
@@ -83,10 +81,6 @@ import {TuiEditorPortalHost} from './portal/editor-portal-host.component';
             provide: TUI_APPEARANCE_OPTIONS,
             useValue: {appearance: 'textfield'},
         },
-        tuiAutoFocusOptionsProvider({
-            delay: TUI_ANIMATIONS_DEFAULT_DURATION,
-            query: '[contenteditable].ProseMirror',
-        }),
     ],
     hostDirectives: [
         {


### PR DESCRIPTION
part of #1462 

Custom `query` config is no longer needed since the default one now includes `[contenteditable]`. Also, the custom query breaks link editor's input autofocus.