### PR TITLE
fix: make "TuiTabExtension" independent of import order

### DIFF
--- a/projects/editor/extensions/indent-outdent/index.ts
+++ b/projects/editor/extensions/indent-outdent/index.ts
@@ -7,6 +7,7 @@ export function tuiIsOrderedOrBulletList(editor: Editor): boolean {
 
 export const TuiTabExtension = Extension.create({
     name: 'indent',
+    priority: 50,
 
     addKeyboardShortcuts(): Record<string, KeyboardShortcutCommand> {
         return {


### PR DESCRIPTION
Fixes #1465

Decreased the tab extension's priority to make it independent of import order. The issue can also be seen in the demo page.