### PR TITLE
fix: fix link editor's button tooltip text

### DIFF
--- a/projects/editor/components/edit-link/edit-link.template.html
+++ b/projects/editor/components/edit-link/edit-link.template.html
@@ -30,7 +30,7 @@
         <button
             appearance="icon"
             size="s"
-            title="Insert link"
+            title="Clear"
             tuiIconButton
             type="button"
             class="t-button"
@@ -40,7 +40,7 @@
         <button
             appearance="icon"
             size="s"
-            title="Insert link"
+            title="Save"
             tuiIconButton
             type="button"
             class="t-button"


### PR DESCRIPTION
Fixes #1469
