### PR TITLE
feat: keyboard shortcut for adding links

### DIFF
--- a/projects/editor/extensions/link/index.ts
+++ b/projects/editor/extensions/link/index.ts
@@ -1,7 +1,56 @@
 import {tuiParseNodeAttributes} from '@taiga-ui/editor/utils';
+import type {Editor, KeyboardShortcutCommand, Range} from '@tiptap/core';
 import {getHTMLFromFragment, markPasteRule} from '@tiptap/core';
 import {Link} from '@tiptap/extension-link';
 import {find} from 'linkifyjs';
+
+function getCurrentWordBounds(editor: Editor): Range {
+    const {state} = editor;
+    const {selection} = state;
+    const {$anchor, empty} = selection;
+
+    if (!empty) {
+        return {
+            from: selection.from,
+            to: selection.to,
+        };
+    }
+
+    if ($anchor) {
+        const {pos} = $anchor;
+        const start = $anchor.start();
+        const parent = $anchor.parent;
+        const textBefore = parent.textBetween(0, pos - start, undefined, '\uFFFC');
+        const textAfter = parent.textBetween(
+            pos - start,
+            parent.content.size,
+            undefined,
+            '\uFFFC',
+        );
+
+        const wordBefore = textBefore
+            .replaceAll(/\uFFFC/, '')
+            .split(/\b/)
+            .pop();
+        const wordAfter = textAfter
+            .replaceAll(/\uFFFC/, '')
+            .split(/\b/)
+            .shift();
+
+        const from = pos - (wordBefore?.length ?? 0);
+        const to = pos + (wordAfter?.length ?? 0);
+
+        return {
+            from,
+            to,
+        };
+    }
+
+    return {
+        from: selection.to,
+        to: selection.to + 1,
+    };
+}
 
 export const TuiLink = Link.extend({
     addAttributes() {
@@ -16,34 +65,52 @@ export const TuiLink = Link.extend({
             ...this.parent?.(),
             toggleLink:
                 (attributes) =>
-                ({chain, state}) => {
+                ({chain, state, editor}) => {
                     // eslint-disable-next-line no-lone-blocks
                     {
-                        const {selection, doc, schema} = state;
-                        const selected = doc.cut(selection.to, selection.to + 1);
+                        const {doc, schema} = state;
+                        const {from, to} = getCurrentWordBounds(editor);
+                        const selected = doc.cut(to, to + 1);
                         const sliced = getHTMLFromFragment(
                             selected.content,
                             schema,
                         ).replaceAll(/<\/?[^>]+(>|$)/g, '');
+
                         const forwardSymbolIsWhitespace = sliced === ' ';
 
-                        const toggleMark = chain().toggleMark(this.name, attributes, {
-                            extendEmptyMarkRange: true,
-                        });
+                        const toggleMark = chain()
+                            .setTextSelection({from, to})
+                            .toggleMark(this.name, attributes, {
+                                extendEmptyMarkRange: true,
+                            });
 
                         return (
                             forwardSymbolIsWhitespace
-                                ? toggleMark.setTextSelection(selection.to - 1)
+                                ? toggleMark.setTextSelection(to - 1)
                                 : toggleMark
-                                      .setTextSelection(selection.to)
+                                      .setTextSelection(to)
                                       .insertContent(
                                           // require: `@tiptap/extension-text-style`
                                           '<span style="font-size: 15px"> </span>',
                                       )
-                                      .setTextSelection(selection.to - 1)
+                                      .setTextSelection(to - 1)
                         ).run();
                     }
                 },
+        };
+    },
+
+    addKeyboardShortcuts(): Record<string, KeyboardShortcutCommand> {
+        return {
+            'Mod-k': ({editor}) => {
+                const isLink = this.editor.isActive('link');
+                const editorChain = editor.chain().focus();
+                const command = isLink
+                    ? editorChain.unsetLink()
+                    : editorChain.toggleLink({href: ''});
+
+                return command.run();
+            },
         };
     },
 

--- a/projects/editor/extensions/link/index.ts
+++ b/projects/editor/extensions/link/index.ts
@@ -29,11 +29,13 @@ function getCurrentWordBounds(editor: Editor): Range {
         );
 
         const wordBefore = textBefore
-            .replaceAll(/\uFFFC/, '')
+            // eslint-disable-next-line unicorn/prefer-string-replace-all
+            .replaceAll(/\uFFFC/g, '')
             .split(/\b/)
             .pop();
         const wordAfter = textAfter
-            .replaceAll(/\uFFFC/, '')
+            // eslint-disable-next-line unicorn/prefer-string-replace-all
+            .replaceAll(/\uFFFC/g, '')
             .split(/\b/)
             .shift();
 


### PR DESCRIPTION
Fixes #1466

As an added bonus, automatically selects word at the current text cursor position. So, you don't have to manually select the word you want to add a link to.
