### PR TITLE
fix: clear contenteditable focus after reset in Safari

### DIFF
--- a/projects/editor/components/editor-socket/editor-socket.component.less
+++ b/projects/editor/components/editor-socket/editor-socket.component.less
@@ -16,7 +16,7 @@
 
     .ProseMirror {
         min-block-size: 100%;
-        padding: 0.2rem 1rem;
+        margin: 0.2rem 1rem;
         outline: none;
         white-space: pre-wrap;
     }


### PR DESCRIPTION
Fixes #1684
