### PR TITLE
fix: added fixes for min/max width options (#1746)

### DIFF
--- a/projects/demo/src/app/pages/images/resizable/examples/1/index.ts
+++ b/projects/demo/src/app/pages/images/resizable/examples/1/index.ts
@@ -4,6 +4,7 @@ import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
 import {
     TUI_EDITOR_EXTENSIONS,
+    TUI_IMAGE_EDITOR_OPTIONS,
     TUI_IMAGE_LOADER,
     TuiEditor,
     TuiEditorSocket,
@@ -26,6 +27,13 @@ import {switchMap} from 'rxjs';
                     tuiCreateImageEditorExtension({injector}),
                 ),
             ],
+        },
+        {
+            provide: TUI_IMAGE_EDITOR_OPTIONS,
+            useValue: {
+                minWidth: 100,
+                maxWidth: 800,
+            },
         },
     ],
 })

--- a/projects/editor/extensions/image-editor/image-editor.component.html
+++ b/projects/editor/extensions/image-editor/image-editor.component.html
@@ -35,6 +35,7 @@
             [style.max-width.px]="maxWidth"
             [style.min-width.px]="minWidth"
             [title]="title"
+            (load)="onImageLoad()"
         />
     </tui-editor-resizable>
 </div>


### PR DESCRIPTION
Fixes [#1746](https://github.com/taiga-family/editor/issues/1746)

- changed image size initialization time from afterViewInit + 100ms to load event trigger time, so naturalWidth DOM image property has actual and correct value;
- changed initialWidth initialization priority, now first priority is attrs.width and only if it is not defined we're trying to get img.naturalWidth;
- now editor content (img attrs) is being updated not only if image natural size is lesser than minWidth, it is also being updated if image natural width is greather than maxWidth;