### PR TITLE
fix: an image can only be selected while the editor is focused

### DIFF
--- a/projects/editor/components/editor-socket/styles/media.less
+++ b/projects/editor/components/editor-socket/styles/media.less
@@ -11,6 +11,6 @@
     }
 }
 
-img.ProseMirror-selectednode {
+.ProseMirror-focused img.ProseMirror-selectednode {
     outline: 0.25rem solid var(--tui-background-accent-1-hover);
 }


### PR DESCRIPTION
Part of https://github.com/taiga-family/editor/pull/1893