### PR TITLE
feat: highlight toolbar icons instead of adding borders

### DIFF
--- a/projects/demo/src/app/pages/custom-tool/color-picker/examples/1/custom-color-picker/index.html
+++ b/projects/demo/src/app/pages/custom-tool/color-picker/examples/1/custom-color-picker/index.html
@@ -1,26 +1,20 @@
-<div>
-    <button
-        appearance="icon"
-        automation-id="toolbar__color-button"
-        size="s"
-        tuiIconButton
-        tuiToolbarTool
-        type="button"
-        [iconStart]="icon || ''"
-        [tuiDropdown]="colorDropdown"
-        [tuiDropdownOpen]="false"
-    >
-        Color options
-    </button>
-    <div
-        tuiPlate
-        [style.background]="fontColor$ | async"
-    ></div>
-</div>
-
+<button
+    appearance="icon"
+    automation-id="toolbar__color-button"
+    size="s"
+    tuiIconButton
+    tuiToolbarTool
+    type="button"
+    [iconStart]="icon || ''"
+    [style.--t-toolbar-icon-color]="fontColor$ | async"
+    [tuiDropdown]="colorDropdown"
+    [tuiDropdownOpen]="false"
+>
+    Color options
+</button>
 <ng-template #colorDropdown>
     <tui-color-selector
-        [color]="selectedColor"
+        [color]="selectedColor || 'transparent'"
         [colors]="colors"
         (colorChange)="onValueChange($event)"
     />

--- a/projects/demo/src/app/pages/custom-tool/color-picker/examples/1/custom-color-picker/index.ts
+++ b/projects/demo/src/app/pages/custom-tool/color-picker/examples/1/custom-color-picker/index.ts
@@ -16,9 +16,6 @@ import {distinctUntilChanged, map, share} from 'rxjs';
     templateUrl: './index.html',
     styleUrls: ['./index.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,
-    host: {
-        tuiPlateHost: '',
-    },
 })
 export class CustomColorPicker {
     private readonly defaultOptions = inject(TUI_EDITOR_OPTIONS);
@@ -26,11 +23,7 @@ export class CustomColorPicker {
     protected selectedColor = '';
     protected readonly editor: AbstractTuiEditor = inject(TuiTiptapEditorService);
     protected readonly fontColor$ = this.editor.valueChange$.pipe(
-        map(() =>
-            this.editor.getOriginTiptapEditor()?.isFocused
-                ? this.editor[`get${this.type}` as const]() || 'transparent'
-                : 'transparent',
-        ),
+        map(() => (this.isBlankColor ? '' : this.color)),
         distinctUntilChanged(),
         share(),
     );
@@ -43,6 +36,18 @@ export class CustomColorPicker {
 
     @Input()
     public type: 'BackgroundColor' | 'FontColor' = 'FontColor';
+
+    protected get color(): string {
+        return this.editor.getOriginTiptapEditor()?.isFocused
+            ? this.editor[`get${this.type}` as const]() || 'transparent'
+            : 'transparent';
+    }
+
+    protected get isBlankColor(): boolean {
+        return (
+            this.color === this.defaultOptions.blankColor || this.color === 'transparent'
+        );
+    }
 
     protected onValueChange(color: string): void {
         this.selectedColor = color;

--- a/projects/editor/components/toolbar-tools/highlight-color/index.ts
+++ b/projects/editor/components/toolbar-tools/highlight-color/index.ts
@@ -18,9 +18,6 @@ import {TuiHighlightColorButtonTool} from '@taiga-ui/editor/tools';
         ></button>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    host: {
-        tuiPlateHost: '',
-    },
 })
 export class TuiHighlightColorTool {
     @Input()

--- a/projects/editor/styles/editor-toolbar.css
+++ b/projects/editor/styles/editor-toolbar.css
@@ -1,4 +1,6 @@
 [tuiToolbar] {
+    --t-toolbar-icon-color: var(--tui-text-tertiary);
+
     display: flex;
     scrollbar-width: none;
     -ms-overflow-style: none;
@@ -69,20 +71,6 @@
     display: none;
 }
 
-[tuiPlateHost] {
-    position: relative;
-}
-
-[tuiPlate] {
-    position: absolute;
-    top: 1.9rem;
-    left: 50%;
-    block-size: 0.25rem;
-    pointer-events: none;
-    transform: translateX(-50%);
-    inline-size: 1.25rem;
-}
-
 [tuiToolbarDropdownContent] {
     padding: 0.5rem;
 }
@@ -90,4 +78,8 @@
 [tuiPalette] {
     box-sizing: border-box;
     max-inline-size: 22.6rem;
+}
+
+[tuiToolbarTool][tuiAppearance][data-appearance='icon']::before {
+    color: var(--t-toolbar-icon-color);
 }

--- a/projects/editor/tools/buttons/highlight-color.ts
+++ b/projects/editor/tools/buttons/highlight-color.ts
@@ -1,4 +1,3 @@
-import {AsyncPipe, NgIf} from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
@@ -26,7 +25,7 @@ import {TuiToolbarButtonTool} from '../tool-button';
 @Component({
     standalone: true,
     selector: 'button[tuiHighlightColorTool]',
-    imports: [AsyncPipe, NgIf, TuiPaletteModule, TuiTextfieldDropdownDirective],
+    imports: [TuiPaletteModule, TuiTextfieldDropdownDirective],
     template: `
         {{ tuiHint() }}
 
@@ -37,20 +36,12 @@ import {TuiToolbarButtonTool} from '../tool-button';
                 (selectedColor)="editor?.setBackgroundColor($event)"
             />
         </ng-container>
-
-        <div
-            *ngIf="!isBlankColor()"
-            tuiPlate
-            [style.background]="editor?.getBackgroundColor()"
-        >
-            <ng-container *ngIf="editor?.valueChange$ | async" />
-        </div>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     hostDirectives: [TuiToolbarButtonTool, TuiDropdownDirective, TuiWithDropdownOpen],
     host: {
-        tuiPlateHost: '',
         '[attr.automation-id]': '"toolbar__hilite-button"',
+        '[style.--t-toolbar-icon-color]': 'getBackgroundColor()',
     },
 })
 export class TuiHighlightColorButtonTool extends TuiToolbarTool {
@@ -65,15 +56,17 @@ export class TuiHighlightColorButtonTool extends TuiToolbarTool {
         this.dropdown.set(template);
     }
 
-    protected isBlankColor(): boolean {
-        return this.editor?.getBackgroundColor() === this.options.blankColor;
-    }
-
     protected getIcon(icons: TuiEditorOptions['icons']): string {
         return icons.textHilite;
     }
 
     protected getHint(texts?: TuiLanguageEditor['toolbarTools']): string {
         return this.open() ? '' : (texts?.backColor ?? '');
+    }
+
+    protected getBackgroundColor(): string {
+        const color = this.editor?.getBackgroundColor() ?? '';
+
+        return color !== 'transparent' ? color : '';
     }
 }

--- a/projects/editor/tools/buttons/paint.ts
+++ b/projects/editor/tools/buttons/paint.ts
@@ -1,4 +1,3 @@
-import {AsyncPipe, NgIf} from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
@@ -25,7 +24,7 @@ import {TuiToolbarButtonTool} from '../tool-button';
 @Component({
     standalone: true,
     selector: 'button[tuiPaintTool]',
-    imports: [AsyncPipe, NgIf, TuiPaletteModule, TuiTextfieldDropdownDirective],
+    imports: [TuiPaletteModule, TuiTextfieldDropdownDirective],
     template: `
         {{ tuiHint() }}
 
@@ -36,19 +35,11 @@ import {TuiToolbarButtonTool} from '../tool-button';
                 (selectedColor)="setCellColor($event)"
             />
         </ng-container>
-
-        <div
-            *ngIf="!isBlankColor()"
-            tuiPlate
-            [style.background]="editor?.getCellColor() ?? editor?.getGroupColor()"
-        >
-            <ng-container *ngIf="editor?.valueChange$ | async" />
-        </div>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     hostDirectives: [TuiToolbarButtonTool, TuiDropdownDirective, TuiWithDropdownOpen],
     host: {
-        tuiPlateHost: '',
+        '[style.--t-toolbar-icon-color]': 'getColor()',
     },
 })
 export class TuiPaintButtonTool extends TuiToolbarTool {
@@ -91,10 +82,9 @@ export class TuiPaintButtonTool extends TuiToolbarTool {
         }
     }
 
-    protected isBlankColor(): boolean {
-        return (
-            (this.editor?.getCellColor() ?? this.editor?.getGroupColor()) ===
-            this.options.blankColor
-        );
+    protected getColor(): string {
+        const color = this.editor?.getCellColor() ?? this.editor?.getGroupColor() ?? '';
+
+        return color !== 'transparent' ? color : '';
     }
 }

--- a/projects/editor/tools/buttons/text-color.ts
+++ b/projects/editor/tools/buttons/text-color.ts
@@ -14,7 +14,11 @@ import {
     TuiTextfieldDropdownDirective,
     TuiWithDropdownOpen,
 } from '@taiga-ui/core';
-import {TUI_EDITOR_OPTIONS, type TuiEditorOptions} from '@taiga-ui/editor/common';
+import {
+    EDITOR_BLANK_COLOR,
+    TUI_EDITOR_OPTIONS,
+    type TuiEditorOptions,
+} from '@taiga-ui/editor/common';
 import {type TuiLanguageEditor} from '@taiga-ui/i18n';
 import {TuiPaletteModule} from '@taiga-ui/legacy';
 import {type PolymorpheusContent} from '@taiga-ui/polymorpheus';
@@ -41,6 +45,7 @@ import {TuiToolbarButtonTool} from '../tool-button';
     hostDirectives: [TuiToolbarButtonTool, TuiDropdownDirective, TuiWithDropdownOpen],
     host: {
         '[attr.automation-id]': '"toolbar__color-button"',
+        '[style.--t-toolbar-icon-color]': 'getFontColor()',
     },
 })
 export class TuiTextColorButtonTool extends TuiToolbarTool {
@@ -61,5 +66,11 @@ export class TuiTextColorButtonTool extends TuiToolbarTool {
 
     protected getHint(texts?: TuiLanguageEditor['toolbarTools']): string {
         return this.open() ? '' : (texts?.foreColor ?? '');
+    }
+
+    protected getFontColor(): string {
+        const color = this.editor?.getFontColor() ?? '';
+
+        return color !== EDITOR_BLANK_COLOR ? color : '';
     }
 }

--- a/projects/editor/tools/tool.ts
+++ b/projects/editor/tools/tool.ts
@@ -21,14 +21,7 @@ import {
 } from '@taiga-ui/editor/common';
 import {TuiTiptapEditorService} from '@taiga-ui/editor/directives';
 import {type TuiLanguageEditor} from '@taiga-ui/i18n';
-import {
-    debounceTime,
-    distinctUntilChanged,
-    map,
-    shareReplay,
-    startWith,
-    type Subscription,
-} from 'rxjs';
+import {shareReplay, startWith, type Subscription} from 'rxjs';
 
 import {TuiToolbarButtonTool} from './tool-button';
 
@@ -78,33 +71,29 @@ export abstract class TuiToolbarTool implements OnChanges, OnDestroy {
     protected abstract getHint(options?: TuiLanguageEditor['toolbarTools']): string;
 
     public ngOnChanges(changes: SimpleChanges): void {
-        if (changes['editor'] && this.getDisableState) {
-            this.subscription?.unsubscribe();
-
-            this.setDisabled(this.getDisableState());
-
-            this.subscription = this.editor?.valueChange$
-                .pipe(
-                    debounceTime(0),
-                    startWith(null),
-                    map(() => this.getDisableState?.() ?? false),
-                    distinctUntilChanged(),
-                    shareReplay({bufferSize: 1, refCount: true}),
-                    tuiWatch(this.cd),
-                    takeUntilDestroyed(this.destroy$),
-                )
-                .subscribe((disabled) => this.setDisabled(disabled));
+        if (!changes['editor']) {
+            return;
         }
+
+        this.subscription?.unsubscribe();
+
+        this.update();
+
+        this.subscription = this.editor?.valueChange$
+            .pipe(
+                startWith(null),
+                shareReplay({bufferSize: 1, refCount: true}),
+                takeUntilDestroyed(this.destroy$),
+                tuiWatch(this.cd),
+            )
+            .subscribe(() => this.update());
     }
 
     public ngOnDestroy(): void {
         this.subscription?.unsubscribe();
     }
 
-    private setDisabled(disabled: boolean): void {
-        this.readOnly.set(disabled);
-
-        // caretaker note: trigger computed effect
-        this.cd.detectChanges();
+    private update(): void {
+        this.readOnly.set(this.getDisableState?.() ?? false);
     }
 }


### PR DESCRIPTION
## Before

<img width="681" height="511" alt="image" src="https://github.com/user-attachments/assets/21330d6b-356a-4b2e-ad98-f8326c3cf3ca" />

<img width="1135" height="508" alt="image" src="https://github.com/user-attachments/assets/9f4071d6-e474-4331-b2c1-bcb8dc9d09d3" />

## After

<img width="1133" height="355" alt="image" src="https://github.com/user-attachments/assets/7ba7c455-1709-4ac6-bcb3-35b8141096e9" />
<img width="1155" height="489" alt="image" src="https://github.com/user-attachments/assets/b0074a1c-6a7e-4ccf-b11c-5eca071f0ab6" />


Part of https://github.com/taiga-family/editor/pull/1887