### PR TITLE
fix: parse only `a` containing `img` to avoid breaking links

### DIFF
--- a/projects/demo/src/app/pages/markdown-extension/examples/1/index.ts
+++ b/projects/demo/src/app/pages/markdown-extension/examples/1/index.ts
@@ -3,14 +3,12 @@ import {
     Component,
     DestroyRef,
     inject,
-    INJECTOR,
-    type Injector,
     type OnInit,
     ViewChild,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {TUI_EDITOR_EXTENSIONS, TuiEditor, TuiEditorTool} from '@taiga-ui/editor';
+import {provideTuiEditor, TuiEditor, TuiEditorTool} from '@taiga-ui/editor';
 import {TuiTextareaModule} from '@taiga-ui/legacy';
 import {type Editor} from '@tiptap/core';
 import {debounceTime, Subject} from 'rxjs';
@@ -30,6 +28,8 @@ const markdown = `# h1 Heading 😎
 ----
 
 ![image info](./assets/icons/logo.svg)
+
+More at [documentation](https://taiga-ui.dev)
 `;
 
 @Component({
@@ -38,28 +38,20 @@ const markdown = `# h1 Heading 😎
     templateUrl: './index.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [
-        {
-            provide: TUI_EDITOR_EXTENSIONS,
-            deps: [INJECTOR],
-            useFactory: (injector: Injector) => [
-                import('@tiptap/starter-kit').then(({StarterKit}) => StarterKit),
-                import('@taiga-ui/editor').then(({tuiCreateImageEditorExtension}) =>
-                    tuiCreateImageEditorExtension({injector}),
-                ),
-                import('@taiga-ui/editor').then(({TuiMarkdown}) =>
-                    TuiMarkdown.configure({
-                        html: true, // Allow HTML input/output
-                        tightLists: true, // No <p> inside <li> in markdown output
-                        tightListClass: 'tight', // Add class to <ul> allowing you to remove <p> margins when tight
-                        bulletListMarker: '-', // <li> prefix in markdown output
-                        linkify: true, // Create links from "https://..." text
-                        breaks: true, // New lines (\n) in markdown input are converted to <br>
-                        transformPastedText: true, // Allow to paste markdown text in the editor
-                        transformCopiedText: true, // Copied text is transformed to markdown
-                    }),
-                ),
-            ],
-        },
+        provideTuiEditor({image: true}, async () =>
+            import('@taiga-ui/editor').then(({TuiMarkdown}) =>
+                TuiMarkdown.configure({
+                    html: true, // Allow HTML input/output
+                    tightLists: true, // No <p> inside <li> in markdown output
+                    tightListClass: 'tight', // Add class to <ul> allowing you to remove <p> margins when tight
+                    bulletListMarker: '-', // <li> prefix in markdown output
+                    linkify: true, // Create links from "https://..." text
+                    breaks: true, // New lines (\n) in markdown input are converted to <br>
+                    transformPastedText: true, // Allow to paste markdown text in the editor
+                    transformCopiedText: true, // Copied text is transformed to markdown
+                }),
+            ),
+        ),
     ],
 })
 export default class Example implements OnInit {

--- a/projects/editor/extensions/image-editor/image-editor.extension.ts
+++ b/projects/editor/extensions/image-editor/image-editor.extension.ts
@@ -87,19 +87,14 @@ export function tuiCreateImageEditorExtension<T, K>({
         parseHTML(): NodeSpec['parseDOM'] {
             return [
                 {
-                    tag: 'a[href]',
+                    tag: 'a[href] img',
                     // Caretaker note:
                     // Tiptap link extension priority is 1000
                     // ensuring current extension is being handled in precedence
                     priority: 1001,
-                    getAttrs: (parsedElement: HTMLElement): TuiEditableImage | false => {
-                        if (parsedElement.firstElementChild?.nodeName !== 'IMG') {
-                            return false;
-                        }
-
+                    getAttrs: (el: HTMLElement): TuiEditableImage | false => {
                         const [href, style] = ['href', 'style'].map(
-                            (attrName) =>
-                                parsedElement.getAttribute(attrName) ?? undefined,
+                            (attrName) => el.getAttribute(attrName) ?? undefined,
                         );
 
                         if (!typesafeIsAllowedUri(href)) {
@@ -113,8 +108,7 @@ export function tuiCreateImageEditorExtension<T, K>({
                             'title',
                         ].map(
                             (attrName) =>
-                                parsedElement.firstElementChild?.getAttribute(attrName) ??
-                                undefined,
+                                el.firstElementChild?.getAttribute(attrName) ?? undefined,
                         );
 
                         return {


### PR DESCRIPTION
Fixes #1971
