### PR TITLE
fix: cursor not visible in an empty editor in Safari 26

### DIFF
--- a/projects/editor/components/editor-socket/editor-socket.component.less
+++ b/projects/editor/components/editor-socket/editor-socket.component.less
@@ -17,7 +17,7 @@
     .ProseMirror {
         min-block-size: 100%;
         margin: 0.2rem 1rem;
-        outline: none;
+        outline: 1px solid transparent;
         white-space: pre-wrap;
     }
 


### PR DESCRIPTION
Fixes #1980
