### PR TITLE
fix(details): parseHTML return only boolean value

### DIFF
--- a/projects/demo-playwright/tests/details.pw.spec.ts
+++ b/projects/demo-playwright/tests/details.pw.spec.ts
@@ -68,7 +68,7 @@ test.describe('Details', () => {
             .locator('tui-toolbar button')
             .locator('text="Details"');
 
-        await contenteditable.click();
+        await contenteditable.locator('p', {hasText: 'Content 1'}).click();
         await page.keyboard.press('End');
         await page.keyboard.press('Enter');
 

--- a/projects/editor/extensions/details/index.ts
+++ b/projects/editor/extensions/details/index.ts
@@ -60,7 +60,7 @@ export const TuiDetailsExtension = Details.extend<TuiDetailsExtensionOptions>({
                     element.getAttribute('open') === 'open' ||
                     element.getAttribute('open') === 'true' ||
                     element.hasAttribute('open') ||
-                    element.getAttribute('data-opened'), // legacy
+                    element.hasAttribute('data-opened'), // legacy
                 renderHTML: (attributes) => ({
                     open:
                         attributes.open && this.options.inheritOpen ? 'open' : undefined,


### PR DESCRIPTION
Hi! This PR fixes a bug where passing the following HTML to TUI Editor:

```html
<details><summary><p></p></summary><div data-type="details-content"><p></p></div></details>
```

Results in it being rendered as:

```html
<details open="open"><summary><p></p></summary><div data-type="details-content"><p></p></div></details>
```

The issue is caused by the `parseHTML` implementation in `addAttributes`. When `parseHTML` returns `null`, ProseMirror treats it as a signal to use the default attribute value. Since the default value is `"open"`, the `<details>` element is rendered in the expanded state.

This behavior is documented in the ProseMirror documentation: https://prosemirror.net/docs/ref/version/0.21.0.html#model.ParseRule.getAttrs
