### PR TITLE
fix: `Details` specify font-family for cross

### DIFF
--- a/projects/editor/components/editor-socket/styles/details.less
+++ b/projects/editor/components/editor-socket/styles/details.less
@@ -81,6 +81,7 @@ details:hover summary::after,
     &::after {
         content: '\00d7';
         display: inline-block;
+        font-family: Arial, Helvetica, sans-serif;
         font-size: 1.5rem;
         color: var(--tui-text-tertiary);
         line-height: 1.125rem;


### PR DESCRIPTION
Fixes #2234
