### PR TITLE
chore(demo): cleanup obsolete meta tags

### DIFF
--- a/projects/demo/src/index.html
+++ b/projects/demo/src/index.html
@@ -14,14 +14,6 @@
             content="width=device-width, initial-scale=1, maximum-scale=1"
             name="viewport"
         />
-        <meta
-            content="Tinkoff"
-            name="author"
-        />
-        <meta
-            content="Tinkoff"
-            name="copyright"
-        />
         <link
             href="assets/manifest.webmanifest"
             rel="manifest"


### PR DESCRIPTION
Removes stale `author` / `copyright` meta tags from the demo `index.html` — they carry outdated information and are not used anywhere.